### PR TITLE
fix: polish dashboard layout, metadata, and accessibility

### DIFF
--- a/public/images/og-card.svg
+++ b/public/images/og-card.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">TajemnikTV</title>
+  <desc id="desc">A dark purple social preview card for the TajemnikTV personal dashboard.</desc>
+  <defs>
+    <radialGradient id="glow" cx="25%" cy="20%" r="80%">
+      <stop offset="0%" stop-color="#8f5cc7" stop-opacity="0.34"/>
+      <stop offset="48%" stop-color="#2a2231" stop-opacity="0.82"/>
+      <stop offset="100%" stop-color="#120d17"/>
+    </radialGradient>
+    <linearGradient id="edge" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.16"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0.03"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="#120d17"/>
+  <rect x="72" y="68" width="1056" height="494" rx="42" fill="url(#glow)" stroke="url(#edge)" stroke-width="2"/>
+  <circle cx="998" cy="144" r="62" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.12"/>
+  <path d="M1005 99 958 190h42l-14 53 62-94h-43l28-50z" fill="#b28ad8"/>
+  <text x="128" y="178" fill="#b28ad8" font-family="Spline Sans, Arial, sans-serif" font-size="28" font-weight="700" letter-spacing="7">TAJEMNIKTV.EXE</text>
+  <text x="128" y="292" fill="#ffffff" font-family="Spline Sans, Arial, sans-serif" font-size="78" font-weight="700">Grzegorz</text>
+  <text x="128" y="382" fill="#ffffff" font-family="Spline Sans, Arial, sans-serif" font-size="78" font-weight="700">Kaczmarski</text>
+  <text x="132" y="460" fill="#d7ccdf" font-family="Spline Sans, Arial, sans-serif" font-size="28" font-weight="500">Projects, lab notes, highlights, and public links.</text>
+  <rect x="128" y="492" width="238" height="48" rx="24" fill="#ffffff" fill-opacity="0.07" stroke="#ffffff" stroke-opacity="0.12"/>
+  <text x="154" y="524" fill="#ffffff" font-family="Spline Sans, Arial, sans-serif" font-size="18" font-weight="700">Astro / Tailwind / GitHub Pages</text>
+</svg>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,8 +7,8 @@
 >
 	<p>Built with Astro • GitHub Pages • Purple enjoyer</p>
 	<div class="flex gap-4 mt-4 md:mt-0">
-		<a class="hover:text-primary transition-colors" href="/rss.xml">RSS</a>
-		<a class="hover:text-primary transition-colors" href="/colophon">Colophon</a
+		<a class="rounded-sm hover:text-primary transition-colors" href="/rss.xml">RSS</a>
+		<a class="rounded-sm hover:text-primary transition-colors" href="/colophon">Colophon</a
 		>
 	</div>
 </div>

--- a/src/components/MobileHeader.astro
+++ b/src/components/MobileHeader.astro
@@ -11,7 +11,7 @@
 		<div
 			class="h-10 w-10 flex items-center justify-center bg-primary rounded-full text-white"
 		>
-			<span class="material-symbols-outlined">bolt</span>
+			<span class="material-symbols-outlined" aria-hidden="true">bolt</span>
 		</div>
 		<span class="font-bold text-lg tracking-tight">TajemnikTV</span>
 	</a>

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -15,16 +15,16 @@ const isActive = (href: string) => {
 ---
 
 <aside
-	class="hidden lg:flex fixed left-8 top-8 bottom-8 w-20 flex-col items-center glass-card rounded-full py-6 z-50 shadow-[0_0_40px_-10px_rgba(127,19,236,0.3)]"
+	class="hidden lg:flex fixed left-8 top-8 bottom-8 w-20 flex-col items-center glass-card rounded-full py-6 z-50 shadow-[0_24px_70px_-35px_rgba(0,0,0,0.85)]"
 >
 	<div class="flex flex-col items-center gap-6 h-full">
 		<!-- Logo -->
 		<a
 			href="/"
-			class="h-10 w-10 flex items-center justify-center bg-primary rounded-full text-white shadow-lg shadow-primary/40 mb-2 hover:scale-110 transition-transform"
+			class="h-10 w-10 flex items-center justify-center bg-primary rounded-full text-white shadow-lg shadow-black/25 mb-2 hover:scale-110 transition-transform"
 			aria-label="TajemnikTV Home"
 		>
-			<span class="material-symbols-outlined text-xl">bolt</span>
+			<span class="material-symbols-outlined text-xl" aria-hidden="true">bolt</span>
 		</a>
 
 		<!-- Nav -->
@@ -44,7 +44,7 @@ const isActive = (href: string) => {
 							aria-label={label}
 							aria-current={active ? "page" : undefined}
 						>
-							<span class="material-symbols-outlined text-xl">{icon}</span>
+							<span class="material-symbols-outlined text-xl" aria-hidden="true">{icon}</span>
 							<span class="absolute left-14 bg-surface-light border border-white/10 text-xs px-2 py-1 rounded-md opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50 shadow-xl">
 								{label}
 							</span>
@@ -61,7 +61,7 @@ const isActive = (href: string) => {
 				href="/rss.xml"
 				aria-label="RSS Feed"
 			>
-				<span class="material-symbols-outlined text-xl">rss_feed</span>
+				<span class="material-symbols-outlined text-xl" aria-hidden="true">rss_feed</span>
 				<span
 					class="absolute left-14 bg-surface-light border border-white/10 text-xs px-2 py-1 rounded-md opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50 shadow-xl"
 					>RSS</span

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -45,7 +45,7 @@ const isActive = (href: string) => {
 							aria-current={active ? "page" : undefined}
 						>
 							<span class="material-symbols-outlined text-xl" aria-hidden="true">{icon}</span>
-							<span class="absolute left-14 bg-surface-light border border-white/10 text-xs px-2 py-1 rounded-md opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50 shadow-xl">
+							<span class="absolute left-14 bg-surface-light border border-white/10 text-xs px-2 py-1 rounded-md opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50 shadow-xl">
 								{label}
 							</span>
 						</a>
@@ -63,7 +63,7 @@ const isActive = (href: string) => {
 			>
 				<span class="material-symbols-outlined text-xl" aria-hidden="true">rss_feed</span>
 				<span
-					class="absolute left-14 bg-surface-light border border-white/10 text-xs px-2 py-1 rounded-md opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50 shadow-xl"
+					class="absolute left-14 bg-surface-light border border-white/10 text-xs px-2 py-1 rounded-md opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-50 shadow-xl"
 					>RSS</span
 				>
 			</a>

--- a/src/components/cards/ElsewhereCard.astro
+++ b/src/components/cards/ElsewhereCard.astro
@@ -63,7 +63,7 @@ const icons: Record<
 		<div
 			class="w-8 h-8 rounded-full bg-white/5 flex items-center justify-center text-white/50"
 		>
-			<span class="material-symbols-outlined text-sm">public</span>
+			<span class="material-symbols-outlined text-sm" aria-hidden="true">public</span>
 		</div>
 	</div>
 
@@ -85,6 +85,7 @@ const icons: Record<
 								class="w-6 h-6 fill-current"
 								viewBox="0 0 24 24"
 								xmlns="http://www.w3.org/2000/svg"
+								aria-hidden="true"
 							>
 								<path d={icon?.path || ""} />
 							</svg>

--- a/src/components/cards/ElsewhereCard.astro
+++ b/src/components/cards/ElsewhereCard.astro
@@ -76,7 +76,7 @@ const icons: Record<
 						class={`flex items-center gap-3 p-3 rounded-xl bg-surface-light ${icon?.bgHover || "hover:bg-white/10"} transition-all group`}
 						href={link.href}
 						target={link.href.startsWith("http") ? "_blank" : undefined}
-						rel={link.href.startsWith("http") ? "noreferrer" : undefined}
+						rel={link.href.startsWith("http") ? "noopener noreferrer" : undefined}
 					>
 						<div
 							class={`text-white/70 ${icon?.hoverColor || "group-hover:text-white"}`}

--- a/src/components/cards/HeroCard.astro
+++ b/src/components/cards/HeroCard.astro
@@ -29,14 +29,14 @@ const {
 ---
 
 <section
-	class="col-span-1 md:col-span-2 lg:col-span-2 row-span-2 relative group overflow-hidden rounded-2xl bg-surface-dark/95 p-7 md:p-8 flex flex-col justify-between min-h-115 border border-white/10 shadow-2xl shadow-primary/10"
+	class="col-span-1 md:col-span-2 lg:col-span-2 row-span-2 relative group overflow-hidden rounded-2xl bg-surface-dark/95 p-7 md:p-8 flex flex-col justify-between min-h-115 border border-white/10 shadow-2xl shadow-black/20"
 >
 	<div
-		class="absolute inset-0 bg-[radial-gradient(circle_at_20%_10%,rgba(157,78,221,0.24),transparent_34%),radial-gradient(circle_at_86%_22%,rgba(34,211,238,0.12),transparent_28%),linear-gradient(135deg,rgba(255,255,255,0.06),transparent_42%)] pointer-events-none"
+		class="absolute inset-0 bg-[radial-gradient(circle_at_18%_8%,rgba(143,92,199,0.16),transparent_32%),linear-gradient(135deg,rgba(255,255,255,0.055),transparent_45%)] pointer-events-none"
 	>
 	</div>
 	<div
-		class="absolute -right-16 -bottom-20 h-64 w-64 rounded-full border border-primary/30 bg-primary/10 blur-2xl pointer-events-none"
+		class="absolute -right-16 -bottom-20 h-64 w-64 rounded-full border border-white/10 bg-white/5 blur-2xl pointer-events-none"
 	>
 	</div>
 
@@ -48,21 +48,19 @@ const {
 				>
 					{handle}.exe
 				</p>
-				<h1
-					class="text-4xl md:text-5xl font-bold mb-3 gradient-text tracking-tight leading-[1.02]"
-				>
+				<h1 class="text-4xl md:text-5xl font-bold mb-3 text-white tracking-tight leading-[1.02]">
 					{name}
 				</h1>
-				<p class="text-sm md:text-base text-cyan-100/80 font-medium max-w-xl">
+				<p class="text-sm md:text-base text-gray-300 font-medium max-w-xl">
 					{tagline}
 				</p>
 			</div>
 
 			<div
-				class="hidden sm:flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-primary shadow-lg shadow-primary/20"
+				class="hidden sm:flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-primary"
 				aria-hidden="true"
 			>
-				<span class="material-symbols-outlined text-4xl">bolt</span>
+				<span class="material-symbols-outlined text-4xl" aria-hidden="true">bolt</span>
 			</div>
 		</div>
 
@@ -86,10 +84,10 @@ const {
 
 	<div class="mt-8 flex flex-wrap gap-3 relative z-10">
 		<a
-			class="px-5 py-3 bg-primary hover:bg-primary/90 text-white rounded-full font-bold text-sm transition-all hover:-translate-y-0.5 active:translate-y-0 flex items-center gap-2 shadow-lg shadow-primary/30"
+			class="px-5 py-3 bg-primary hover:bg-primary/90 text-white rounded-full font-bold text-sm transition-all hover:-translate-y-0.5 active:translate-y-0 flex items-center gap-2 shadow-lg shadow-black/25"
 			href={primaryCta.href}
 		>
-			<span class="material-symbols-outlined text-[20px]"
+			<span class="material-symbols-outlined text-[20px]" aria-hidden="true"
 				>{primaryCta.icon}</span
 			>
 			{primaryCta.label}
@@ -98,7 +96,7 @@ const {
 			class="px-5 py-3 bg-white/5 hover:bg-white/10 text-white border border-white/15 rounded-full font-semibold text-sm transition-all flex items-center gap-2"
 			href={secondaryCta.href}
 		>
-			<span class="material-symbols-outlined text-[20px]">
+			<span class="material-symbols-outlined text-[20px]" aria-hidden="true">
 				{secondaryCta.icon}
 			</span>
 			{secondaryCta.label}

--- a/src/components/cards/HeroCard.astro
+++ b/src/components/cards/HeroCard.astro
@@ -60,7 +60,7 @@ const {
 				class="hidden sm:flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-primary"
 				aria-hidden="true"
 			>
-				<span class="material-symbols-outlined text-4xl" aria-hidden="true">bolt</span>
+				<span class="material-symbols-outlined text-4xl">bolt</span>
 			</div>
 		</div>
 

--- a/src/components/cards/LabNotesCard.astro
+++ b/src/components/cards/LabNotesCard.astro
@@ -14,10 +14,10 @@ const { title, status, description, emptyTitle, emptyDescription, href } =
 
 <a
 	href={href}
-	class="col-span-1 md:col-span-2 bg-surface-dark relative overflow-hidden rounded-2xl group min-h-62.5 flex border border-white/10 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-primary/50"
+	class="col-span-1 md:col-span-2 bg-surface-dark relative overflow-hidden rounded-2xl group min-h-62.5 flex border border-white/10 shadow-lg shadow-black/20 transition-all duration-300 hover:-translate-y-1 hover:border-primary/40"
 >
 	<div
-		class="absolute inset-0 bg-[linear-gradient(135deg,rgba(127,19,236,0.22),transparent_42%),radial-gradient(circle_at_82%_22%,rgba(34,211,238,0.14),transparent_30%)]"
+		class="absolute inset-0 bg-[linear-gradient(135deg,rgba(143,92,199,0.15),transparent_44%),radial-gradient(circle_at_82%_22%,rgba(255,255,255,0.06),transparent_32%)]"
 	>
 	</div>
 	<div class="absolute inset-x-0 bottom-0 h-px bg-primary/60"></div>
@@ -30,10 +30,10 @@ const { title, status, description, emptyTitle, emptyDescription, href } =
 				>
 					{title}
 				</span>
-				<span class="text-xs text-cyan-100/75 font-semibold">{status}</span>
+				<span class="text-xs text-gray-300 font-semibold">{status}</span>
 			</div>
 			<h3
-				class="text-2xl md:text-3xl font-bold text-white mb-3 leading-tight group-hover:text-cyan-100 transition-colors"
+				class="text-2xl md:text-3xl font-bold text-white mb-3 leading-tight transition-colors"
 			>
 				{emptyTitle}
 			</h3>
@@ -47,9 +47,10 @@ const { title, status, description, emptyTitle, emptyDescription, href } =
 				{description}
 			</p>
 			<span
-				class="hidden sm:flex h-10 w-10 shrink-0 rounded-full bg-primary text-white items-center justify-center shadow-lg shadow-primary/30 group-hover:translate-x-1 transition-transform"
+				class="hidden sm:flex h-10 w-10 shrink-0 rounded-full bg-primary text-white items-center justify-center shadow-lg shadow-black/25 group-hover:translate-x-1 transition-transform"
+				aria-hidden="true"
 			>
-				<span class="material-symbols-outlined">arrow_forward</span>
+				<span class="material-symbols-outlined" aria-hidden="true">arrow_forward</span>
 			</span>
 		</div>
 	</div>

--- a/src/components/cards/LabNotesCard.astro
+++ b/src/components/cards/LabNotesCard.astro
@@ -50,7 +50,7 @@ const { title, status, description, emptyTitle, emptyDescription, href } =
 				class="hidden sm:flex h-10 w-10 shrink-0 rounded-full bg-primary text-white items-center justify-center shadow-lg shadow-black/25 group-hover:translate-x-1 transition-transform"
 				aria-hidden="true"
 			>
-				<span class="material-symbols-outlined" aria-hidden="true">arrow_forward</span>
+				<span class="material-symbols-outlined">arrow_forward</span>
 			</span>
 		</div>
 	</div>

--- a/src/components/cards/PillarCard.astro
+++ b/src/components/cards/PillarCard.astro
@@ -27,7 +27,7 @@ const style = colorStyles[color] || colorStyles.default;
 	<div
 		class={`w-12 h-12 rounded-2xl ${style.bg} ${style.text} flex items-center justify-center group-hover:scale-110 transition-transform duration-300`}
 	>
-		<span class="material-symbols-outlined text-3xl">{icon}</span>
+		<span class="material-symbols-outlined text-3xl" aria-hidden="true">{icon}</span>
 	</div>
 	<div>
 		<h3 class="text-lg font-bold text-white mb-2 leading-tight">{title}</h3>

--- a/src/components/cards/PostCard.astro
+++ b/src/components/cards/PostCard.astro
@@ -18,7 +18,7 @@ const formattedDate = pubDate.toLocaleDateString("en-US", {
 
 <a
 	href={`/lab/${slug}`}
-	class="group relative block bg-surface-dark border border-white/5 rounded-2xl overflow-hidden hover:border-primary/50 transition-all duration-300 hover:scale-[1.01] hover:shadow-xl hover:shadow-primary/10"
+	class="group relative block bg-surface-dark border border-white/5 rounded-2xl overflow-hidden hover:border-primary/40 transition-all duration-300 hover:scale-[1.01] hover:shadow-xl hover:shadow-black/20"
 >
 	<div class="flex flex-col md:flex-row h-full">
 		{

--- a/src/components/cards/ProjectCard.astro
+++ b/src/components/cards/ProjectCard.astro
@@ -5,9 +5,11 @@ interface Props {
 	description: string;
 	tags: string[];
 	href?: string;
+	featured?: boolean;
 }
 
-const { title, subtitle, description, tags, href } = Astro.props;
+const { title, subtitle, description, tags, href, featured = false } =
+	Astro.props;
 const Wrapper = href ? "a" : "article";
 ---
 
@@ -15,31 +17,50 @@ const Wrapper = href ? "a" : "article";
 	href={href}
 	target={href?.startsWith("http") ? "_blank" : undefined}
 	rel={href?.startsWith("http") ? "noreferrer" : undefined}
-	class="group col-span-1 bg-surface-dark/90 border border-white/5 rounded-2xl p-5 min-h-61.25 flex flex-col hover:border-primary/50 hover:-translate-y-0.5 transition-all"
+	class:list={[
+		"group bg-surface-dark/90 border border-white/7 rounded-2xl flex flex-col hover:border-primary/40 hover:-translate-y-0.5 transition-all shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]",
+		featured
+			? "col-span-1 md:col-span-2 lg:col-span-2 min-h-76 p-6 md:p-7 bg-[linear-gradient(145deg,rgba(35,28,43,0.96),rgba(22,17,28,0.96))]"
+			: "col-span-1 min-h-61.25 p-5",
+	]}
 >
 	<div class="flex items-start justify-between gap-4 mb-4">
 		<div>
 			<p
-				class="text-xs font-bold uppercase tracking-[0.16em] text-primary mb-2"
+				class="text-xs font-bold uppercase tracking-[0.16em] text-primary/85 mb-2"
 			>
 				{subtitle}
 			</p>
-			<h3 class="text-xl font-bold text-white leading-tight">{title}</h3>
+			<h3
+				class:list={[
+					"font-bold text-white leading-tight",
+					featured ? "text-2xl md:text-3xl" : "text-xl",
+				]}
+			>
+				{title}
+			</h3>
 		</div>
 		<span
-			class="material-symbols-outlined text-white/30 group-hover:text-primary transition-colors"
+			class="material-symbols-outlined text-white/30 group-hover:text-primary/90 transition-colors"
 			aria-hidden="true"
 		>
 			arrow_outward
 		</span>
 	</div>
 
-	<p class="text-sm text-gray-300 leading-relaxed flex-1">{description}</p>
+	<p
+		class:list={[
+			"text-gray-300 leading-relaxed flex-1",
+			featured ? "text-base max-w-2xl" : "text-sm",
+		]}
+	>
+		{description}
+	</p>
 
 	<div class="mt-5 flex flex-wrap gap-2">
 		{
 			tags.map((tag) => (
-				<span class="rounded-full bg-white/6 border border-white/10 px-2.5 py-1 text-[11px] font-semibold text-gray-300">
+				<span class="rounded-md bg-white/6 border border-white/8 px-2.5 py-1 text-[11px] font-semibold text-gray-300">
 					{tag}
 				</span>
 			))

--- a/src/components/cards/ProjectCard.astro
+++ b/src/components/cards/ProjectCard.astro
@@ -16,7 +16,7 @@ const Wrapper = href ? "a" : "article";
 <Wrapper
 	href={href}
 	target={href?.startsWith("http") ? "_blank" : undefined}
-	rel={href?.startsWith("http") ? "noreferrer" : undefined}
+	rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
 	class:list={[
 		"group bg-surface-dark/90 border border-white/7 rounded-2xl flex flex-col hover:border-primary/40 hover:-translate-y-0.5 transition-all shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]",
 		featured

--- a/src/components/cards/ReadingCard.astro
+++ b/src/components/cards/ReadingCard.astro
@@ -9,10 +9,10 @@ const { title, description, items } = Astro.props;
 ---
 
 <section
-	class="col-span-1 md:col-span-2 bg-[#191021] p-6 rounded-2xl border border-white/10 overflow-hidden flex flex-col relative"
+	class="col-span-1 md:col-span-2 bg-[#19151f] p-6 rounded-2xl border border-white/10 overflow-hidden flex flex-col relative"
 >
 	<div
-		class="absolute -right-12 -top-16 h-44 w-44 rounded-full bg-cyan-400/10 blur-3xl"
+		class="absolute -right-12 -top-16 h-44 w-44 rounded-full bg-white/6 blur-3xl"
 		aria-hidden="true"
 	>
 	</div>
@@ -20,18 +20,16 @@ const { title, description, items } = Astro.props;
 		<div class="flex items-center justify-between gap-4 mb-5">
 			<div>
 				<p
-					class="flex items-center gap-2 text-xs text-cyan-200 font-bold uppercase tracking-[0.18em] mb-2"
+					class="flex items-center gap-2 text-xs text-gray-300 font-bold uppercase tracking-[0.18em] mb-2"
 				>
-					<span class="material-symbols-outlined text-base">travel_explore</span
+					<span class="material-symbols-outlined text-base" aria-hidden="true">travel_explore</span
 					>
 					Input Queue
 				</p>
 				<h3 class="text-2xl font-bold text-white leading-tight">{title}</h3>
 			</div>
-			<div
-				class="h-10 w-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center text-cyan-200"
-			>
-				<span class="material-symbols-outlined">radar</span>
+			<div class="h-10 w-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center text-gray-300">
+				<span class="material-symbols-outlined" aria-hidden="true">radar</span>
 			</div>
 		</div>
 
@@ -43,7 +41,7 @@ const { title, description, items } = Astro.props;
 			{
 				items.map((item) => (
 					<li class="flex items-start gap-2 rounded-xl border border-white/5 bg-white/4 px-3 py-2 text-sm text-gray-200">
-						<span class="material-symbols-outlined text-primary text-base mt-0.5">
+						<span class="material-symbols-outlined text-primary text-base mt-0.5" aria-hidden="true">
 							chevron_right
 						</span>
 						<span>{item}</span>

--- a/src/data/dashboard.ts
+++ b/src/data/dashboard.ts
@@ -65,6 +65,7 @@ export const dashboardData = {
     {
       title: "TajsGraph",
       subtitle: "Satisfactory graphics overhaul",
+      featured: true,
       description:
         "Rendering obsession packaged as a modding project: cleaner visuals, better defaults, and a lot of staring at settings until they confess.",
       tags: ["Satisfactory", "graphics", "rendering", "modding"],

--- a/src/data/dashboard.ts
+++ b/src/data/dashboard.ts
@@ -8,8 +8,8 @@ export const dashboardData = {
     bio: siteData.bio,
     aside: siteData.secondaryBio,
     statusChips: [
-      siteData.currentActivity ?? "Currently: tweaking systems",
-      "Mode: overthinking with purpose",
+      siteData.currentActivity ?? "Currently: tuning the workbench",
+      "Mode: careful tinkering",
       `Location: ${siteData.location}`,
       "Stack: Astro / Tailwind / GitHub Pages",
     ],
@@ -35,7 +35,7 @@ export const dashboardData = {
     {
       title: "Game modding & UX",
       description:
-        "Fixing friction, reshaping interfaces, and making game systems feel better without pretending the rabbit hole is small.",
+        "Fixing friction, reshaping interfaces, and making game mechanics feel better without pretending the work is small.",
       icon: "extension",
       color: "orange",
     },
@@ -56,7 +56,7 @@ export const dashboardData = {
     {
       title: "Tools & digital life systems",
       description:
-        "Personal dashboards, automation, second-brain experiments, and other attempts to make chaos searchable.",
+        "Personal dashboards, automation, second-brain experiments, and other attempts to keep context findable.",
       icon: "hub",
       color: "violet",
     },
@@ -82,7 +82,7 @@ export const dashboardData = {
       title: "TajsOS",
       subtitle: "Personal LifeOS experiment",
       description:
-        "A second-brain style app idea for tasks, notes, mood, systems, and the daily attempt to remember what the plan was.",
+        "A second-brain style app idea for tasks, mood, project context, and the daily attempt to remember what the plan was.",
       tags: ["LifeOS", "notes", "automation", "systems"],
       href: "https://github.com/tajemniktv",
     },
@@ -104,9 +104,9 @@ export const dashboardData = {
     },
   ],
   inputQueue: {
-    title: "Current rabbit holes",
+    title: "Current input queue",
     description:
-      "A rotating input queue instead of a fake bookshelf. Some of this becomes notes. Some of it becomes ten browser tabs and a suspiciously specific opinion.",
+      "A rotating input queue instead of a fake bookshelf. Some of this becomes lab material. Some of it becomes ten browser tabs and a suspiciously specific opinion.",
     items: [
       "Psychometrics, attention, and behavior loops",
       "Satisfactory rendering and UI polish",
@@ -117,12 +117,12 @@ export const dashboardData = {
   },
   lab: {
     title: "Lab Notes",
-    status: "Currently incubating",
+    status: "Drafts in progress",
     description:
-      "Not a formal blog. More like experiments, rabbit holes, project notes, half-polished thoughts, and occasional brain dumps that survived long enough to be useful.",
-    emptyTitle: "Public notes are still booting",
+      "Not a formal blog. More like experiments, project logs, half-polished thoughts, and occasional brain dumps that survived long enough to be useful.",
+    emptyTitle: "Public notes will stay selective",
     emptyDescription:
-      "The old placeholder essays are staying private until they stop sounding like a template wearing a trench coat.",
+      "The old placeholder essays are staying private. The public lab is for entries with enough shape to be useful.",
     href: "/lab",
   },
   elsewhere: siteData.socials,

--- a/src/data/highlights.ts
+++ b/src/data/highlights.ts
@@ -25,9 +25,9 @@ export const highlightsData: HighlightItem[] = [
     slug: "psychology",
     title: "Psychology & mind systems",
     icon: "psychology",
-    description: "Attention, behavior, measurement, and the messy system UI of being a person.",
+    description: "Attention, behavior, measurement, and the messy control panel of being a person.",
     hero: {
-      statusChip: "Currently overthinking with purpose",
+      statusChip: "Currently reading around psychometrics",
       subtitle:
         "Psychology is the lens: attention, motivation, self-regulation, measurement, identity, and the strange ways systems shape people.",
     },
@@ -37,13 +37,13 @@ export const highlightsData: HighlightItem[] = [
         items: [
           { label: "Psychometrics", description: "How we measure traits, validity, and human variance without pretending the map is the territory." },
           { label: "Attention loops", description: "Interfaces, reward systems, friction, and the tiny mechanics that steer behavior." },
-          { label: "Systems thinking", description: "Personal workflows, habits, motivation, and feedback loops viewed as one tangled machine." },
+          { label: "Feedback loops", description: "Personal workflows, habits, motivation, and behavior viewed as one tangled machine." },
         ],
       },
       {
         title: "Likely lab-note territory",
         items: [
-          { label: "Cognitive load in interfaces", description: "Notes currently incubating.", icon: "pending" },
+          { label: "Cognitive load in interfaces", description: "Draft queue.", icon: "pending" },
           { label: "Avatars, identity, and game systems", description: "Draft pile. Not public yet.", icon: "pending" },
         ],
       },
@@ -63,7 +63,7 @@ export const highlightsData: HighlightItem[] = [
       {
         title: "Project lanes",
         items: [
-          { label: "TajsGraph", description: "Satisfactory graphics overhaul and rendering-tweak rabbit hole.", href: "https://github.com/tajemniktv" },
+          { label: "TajsGraph", description: "Satisfactory graphics overhaul and rendering-tweak project lane.", href: "https://github.com/tajemniktv" },
           { label: "Taj's Mods", description: "Upload Labs / Godot-flavored mod ecosystem ideas.", href: "https://github.com/tajemniktv" },
           { label: "UEiniLab", description: "Unreal Engine INI and CVar tooling experiments.", href: "https://github.com/tajemniktv" },
         ],
@@ -130,9 +130,9 @@ export const highlightsData: HighlightItem[] = [
     slug: "systems",
     title: "Tools & digital life systems",
     icon: "hub",
-    description: "Personal dashboards, automation, notes, and attempts to make chaos searchable.",
+    description: "Personal dashboards, automation, notes, and attempts to keep context findable.",
     hero: {
-      statusChip: "TajsOS somewhere in the lab",
+      statusChip: "TajsOS on the bench",
       subtitle:
         "I keep trying to build better personal control panels: notes, tasks, moods, projects, context, and the daily fight against forgotten intent.",
     },

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -4,15 +4,15 @@ export const siteData = {
   shortName: "Taj",
   location: "Radom, Poland",
   tagline:
-    "Hobbyist developer • modder • graphics tinkerer • psychology enjoyer • professional overthinker",
-  bio: "Psychology student, modder, graphics tinkerer, and professional overthinker. I collect ideas about minds, systems, games, interfaces, and occasionally turn the chaos into something useful.",
+    "Hobbyist developer • modder • graphics tinkerer • psychology enjoyer • patient debugger",
+  bio: "Psychology student, modder, and graphics tinkerer. I collect ideas about minds, games, interfaces, and occasionally turn the mess into something useful.",
   secondaryBio:
     "Broad interests, questionable sleep schedule, and way too many ideas.",
   status: {
-    text: "Systems awake",
+    text: "Workbench awake",
     color: "violet",
   },
-  currentActivity: "Currently: tweaking systems",
+  currentActivity: "Currently: tuning the workbench",
   socials: [
     {
       title: "GitHub",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,19 +3,38 @@ import "../styles/global.css";
 
 interface Props {
 	title: string;
+	description?: string;
+	image?: string;
 }
 
-const { title } = Astro.props;
+const {
+	title,
+	description = "TajemnikTV is Grzegorz Kaczmarski's personal dashboard for projects, lab notes, highlights, and public links.",
+	image = "/images/avatar-placeholder.png",
+} = Astro.props;
+
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin);
+const imageUrl = new URL(image, Astro.site ?? Astro.url.origin);
 ---
 
 <!doctype html>
 <html lang="en" class="dark scroll-smooth">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="description" content="TajemnikTV Personal Dashboard" />
+		<meta name="description" content={description} />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="canonical" href={canonicalUrl} />
 		<meta name="generator" content={Astro.generator} />
+		<meta property="og:type" content="website" />
+		<meta property="og:title" content={title} />
+		<meta property="og:description" content={description} />
+		<meta property="og:url" content={canonicalUrl} />
+		<meta property="og:image" content={imageUrl} />
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
+		<meta name="twitter:image" content={imageUrl} />
 		<slot name="head" />
 
 		<!-- Google Fonts -->

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,8 +13,8 @@ const {
 	image = "/images/avatar-placeholder.png",
 } = Astro.props;
 
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin);
-const imageUrl = new URL(image, Astro.site ?? Astro.url.origin);
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
+const imageUrl = new URL(image, Astro.site);
 ---
 
 <!doctype html>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,11 +10,12 @@ interface Props {
 const {
 	title,
 	description = "TajemnikTV is Grzegorz Kaczmarski's personal dashboard for projects, lab notes, highlights, and public links.",
-	image = "/images/avatar-placeholder.png",
+	image = "/images/og-card.svg",
 } = Astro.props;
 
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
-const imageUrl = new URL(image, Astro.site);
+const siteUrl = Astro.site ?? new URL("https://tajemniktv.github.io");
+const canonicalUrl = new URL(Astro.url.pathname, siteUrl);
+const imageUrl = new URL(image, siteUrl);
 ---
 
 <!doctype html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -21,9 +21,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 					class="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-primary"
 					aria-hidden="true"
 				>
-					<span class="material-symbols-outlined text-3xl" aria-hidden="true"
-						>explore_off</span
-					>
+					<span class="material-symbols-outlined text-3xl">explore_off</span>
 				</div>
 				<h1 class="text-4xl font-bold text-white mb-2">404</h1>
 				<p class="text-xl text-primary font-bold mb-6">Level Not Found</p>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -15,9 +15,16 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 			<MobileHeader />
 
 			<GlassCard
-				class="p-12 text-center max-w-md w-full border-red-500/20 shadow-[0_0_50px_-20px_rgba(239,68,68,0.2)]"
+				class="p-12 text-center max-w-md w-full border-white/10"
 			>
-				<div class="text-6xl mb-4">👾</div>
+				<div
+					class="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-primary"
+					aria-hidden="true"
+				>
+					<span class="material-symbols-outlined text-3xl" aria-hidden="true"
+						>explore_off</span
+					>
+				</div>
 				<h1 class="text-4xl font-bold text-white mb-2">404</h1>
 				<p class="text-xl text-primary font-bold mb-6">Level Not Found</p>
 				<p class="text-gray-400 mb-8">
@@ -28,7 +35,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 					href="/"
 					class="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white font-bold py-3 px-8 rounded-full transition-transform hover:scale-105"
 				>
-					<span class="material-symbols-outlined">home</span>
+					<span class="material-symbols-outlined" aria-hidden="true">home</span>
 					Respawn Home
 				</a>
 			</GlassCard>

--- a/src/pages/colophon.astro
+++ b/src/pages/colophon.astro
@@ -35,6 +35,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 							<a
 								href="https://astro.build"
 								target="_blank"
+								rel="noopener noreferrer"
 								class="text-lg font-bold text-white hover:text-primary transition-colors"
 								>Astro</a
 							>
@@ -48,6 +49,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 							<a
 								href="https://tailwindcss.com"
 								target="_blank"
+								rel="noopener noreferrer"
 								class="text-lg font-bold text-white hover:text-primary transition-colors"
 								>Tailwind CSS</a
 							>
@@ -61,6 +63,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 							<a
 								href="https://pages.github.com"
 								target="_blank"
+								rel="noopener noreferrer"
 								class="text-lg font-bold text-white hover:text-primary transition-colors"
 								>GitHub Pages</a
 							>

--- a/src/pages/connect.astro
+++ b/src/pages/connect.astro
@@ -9,7 +9,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 const { socials, bio, secondaryBio } = siteData;
 ---
 
-<BaseLayout title="Connect | TajemnikTV">
+<BaseLayout
+	title="Connect | TajemnikTV"
+	description="Verified public links and profile context for TajemnikTV."
+>
 	<div class="flex min-h-screen w-full relative">
 		<Sidebar />
 
@@ -19,9 +22,7 @@ const { socials, bio, secondaryBio } = siteData;
 			<MobileHeader />
 
 			<header class="mb-12">
-				<h1 class="text-4xl md:text-5xl font-bold mb-4 gradient-text">
-					Connect
-				</h1>
+				<h1 class="text-4xl md:text-5xl font-bold mb-4 text-white">Connect</h1>
 				<p class="text-lg text-gray-300 max-w-2xl">
 					Places where TajemnikTV exists publicly. No fake contact form, no
 					recruiter bait, no mystery inbox.
@@ -62,12 +63,12 @@ const { socials, bio, secondaryBio } = siteData;
 					<ElsewhereCard links={socials} />
 
 					<GlassCard
-						class="p-6 bg-linear-to-br from-indigo-900/40 to-purple-900/40 border-indigo-500/20"
+						class="p-6 bg-[linear-gradient(145deg,rgba(36,29,44,0.9),rgba(24,19,30,0.9))] border-white/10"
 					>
 						<h3
 							class="text-xl font-bold text-white mb-2 flex items-center gap-2"
 						>
-							<span class="material-symbols-outlined">handshake</span>
+							<span class="material-symbols-outlined" aria-hidden="true">handshake</span>
 							Current posture
 						</h3>
 						<p class="text-sm text-gray-300 mb-4">
@@ -77,7 +78,7 @@ const { socials, bio, secondaryBio } = siteData;
 						<div
 							class="flex items-center gap-2 text-xs font-bold text-indigo-300 uppercase tracking-widest"
 						>
-							Mode: <span class="text-cyan-200">Overthinking with purpose</span>
+							Mode: <span class="text-gray-200">Careful tinkering</span>
 						</div>
 					</GlassCard>
 				</div>

--- a/src/pages/highlights.astro
+++ b/src/pages/highlights.astro
@@ -8,9 +8,13 @@ import { highlightsData } from "../data/highlights";
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 const { inputQueue } = dashboardData;
+const [featuredHighlight, ...supportingHighlights] = highlightsData;
 ---
 
-<BaseLayout title="Highlights | TajemnikTV">
+<BaseLayout
+	title="Highlights | TajemnikTV"
+	description="The recurring interests behind TajemnikTV: psychology, modding, graphics, music, and practical personal tooling."
+>
 	<div class="flex min-h-screen w-full relative">
 		<Sidebar />
 
@@ -27,73 +31,104 @@ const { inputQueue } = dashboardData;
 						<span class="w-2 h-2 rounded-full bg-primary animate-pulse"></span>
 						<span
 							class="text-xs font-bold text-gray-300 uppercase tracking-wide"
-							>Systems, taste, feelings, config files</span
+							>Mind, games, rendering, music, tools</span
 						>
 					</div>
 				</div>
-				<h1 class="text-4xl md:text-5xl font-bold mb-4 gradient-text">
-					Highlights
-				</h1>
+				<h1 class="text-4xl md:text-5xl font-bold mb-4 text-white">Highlights</h1>
 				<p class="text-lg text-gray-300 max-w-2xl">
-					The recurring obsessions behind the dashboard: mind systems, games,
-					visuals, music, tools, and the very human urge to make chaos legible.
+					The recurring interests behind the dashboard: mind, games, visuals,
+					music, tools, and the very human urge to make things easier to read.
 				</p>
 			</header>
 
-			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-				<!-- Main Interest Areas -->
-				{
-					highlightsData.map((item) => (
-						<GlassCard class="p-6 flex flex-col gap-4 group" hoverEffect={true}>
-							<div class="w-12 h-12 rounded-2xl bg-primary/20 text-primary flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-								<span class="material-symbols-outlined text-3xl">
-									{item.icon}
+			<div
+				class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(24rem,0.9fr)] gap-6 items-start"
+			>
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-6 self-start">
+					<a
+						href={`/highlights/${featuredHighlight.slug}`}
+						class="group md:col-span-2 rounded-2xl border border-white/8 bg-surface-dark/85 p-7 md:p-8 transition-all hover:border-primary/35 hover:bg-white/5 min-h-72"
+					>
+						<div class="flex items-start justify-between gap-5">
+							<div class="max-w-2xl">
+								<p class="text-xs font-bold uppercase tracking-[0.18em] text-primary/85 mb-3">
+									Lead thread
+								</p>
+								<h2 class="text-3xl font-bold text-white mb-3">
+									{featuredHighlight.title}
+								</h2>
+								<p class="text-gray-300 leading-relaxed">
+									{featuredHighlight.hero.subtitle}
+								</p>
+							</div>
+							<div class="hidden sm:flex h-14 w-14 rounded-2xl bg-white/6 border border-white/8 items-center justify-center text-primary/90">
+								<span class="material-symbols-outlined text-3xl" aria-hidden="true">
+									{featuredHighlight.icon}
 								</span>
 							</div>
-							<div>
-								<h3 class="text-xl font-bold text-white mb-2">{item.title}</h3>
-								<p class="text-sm text-gray-300 mb-4">{item.description}</p>
-								<a
-									href={`/highlights/${item.slug}`}
-									class="text-xs font-bold uppercase tracking-wider text-primary hover:text-white transition-colors flex items-center gap-1"
-								>
-									Explore{" "}
-									<span class="material-symbols-outlined text-sm">
-										arrow_forward
-									</span>
-								</a>
-							</div>
-						</GlassCard>
-					))
-				}
-
-				<!-- Currently Reading (Reusing component) -->
-				<ReadingCard {...inputQueue} />
-
-				<!-- Detailed Blocks (Example) -->
-				<GlassCard class="col-span-1 md:col-span-2 lg:col-span-2 p-6 md:p-8">
-					<div class="flex items-start gap-4 mb-4">
-						<span class="material-symbols-outlined text-3xl text-accent-purple"
-							>psychology</span
-						>
-						<div>
-							<h3 class="text-2xl font-bold text-white mb-2">
-								Why these pillars?
-							</h3>
-							<p class="text-gray-300 leading-relaxed mb-4">
-								They are not resume categories. They are the repeat offenders:
-								psychology explains the humans, modding exposes the systems,
-								rendering rewards obsessive tuning, music handles the emotional
-								backlog, and tooling tries to keep all of it searchable.
-							</p>
-							<p class="text-gray-300 leading-relaxed">
-								The overlap is the point. A game UI, a study note, a playlist,
-								and a personal dashboard can all be attempts to manage
-								attention.
-							</p>
 						</div>
-					</div>
-				</GlassCard>
+						<div class="mt-6 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.16em] text-gray-400 group-hover:text-white transition-colors">
+							Open highlight
+							<span class="material-symbols-outlined text-sm" aria-hidden="true">
+								arrow_forward
+							</span>
+						</div>
+					</a>
+
+					<GlassCard class="md:col-span-2 p-6 md:p-8">
+						<div class="flex items-start gap-4 mb-4">
+							<span class="material-symbols-outlined text-3xl text-accent-purple" aria-hidden="true"
+								>psychology</span
+							>
+							<div>
+								<h3 class="text-2xl font-bold text-white mb-2">
+									Why these pillars?
+								</h3>
+								<p class="text-gray-300 leading-relaxed mb-4">
+									They are not resume categories. They are repeat signals:
+									psychology explains the humans, modding exposes the mechanics,
+									rendering rewards careful tuning, music handles the emotional
+									backlog, and tooling keeps the work searchable.
+								</p>
+								<p class="text-gray-300 leading-relaxed">
+									The overlap is the point. A game UI, a study note, a playlist,
+									and a personal dashboard can all be attempts to manage
+									attention.
+								</p>
+							</div>
+						</div>
+					</GlassCard>
+				</div>
+
+				<aside class="flex flex-col gap-4 self-start">
+					{
+						supportingHighlights.map((item) => (
+							<a
+								href={`/highlights/${item.slug}`}
+								class="group rounded-2xl border border-white/7 bg-white/4 p-5 transition-all hover:border-primary/35 hover:bg-white/7"
+							>
+								<div class="grid grid-cols-[2.5rem_minmax(0,1fr)] gap-4">
+									<div class="w-10 h-10 rounded-xl bg-surface-light border border-white/8 text-primary/90 flex items-center justify-center shrink-0">
+										<span class="material-symbols-outlined text-2xl" aria-hidden="true">
+											{item.icon}
+										</span>
+									</div>
+									<div class="min-w-0">
+										<h3 class="font-bold text-white mb-1 leading-snug">
+											{item.title}
+										</h3>
+										<p class="text-sm text-gray-400 leading-relaxed">
+											{item.description}
+										</p>
+									</div>
+								</div>
+							</a>
+						))
+					}
+
+					<ReadingCard {...inputQueue} />
+				</aside>
 			</div>
 		</main>
 	</div>

--- a/src/pages/highlights.astro
+++ b/src/pages/highlights.astro
@@ -8,6 +8,9 @@ import { highlightsData } from "../data/highlights";
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 const { inputQueue } = dashboardData;
+if (highlightsData.length === 0) {
+	throw new Error("highlightsData must contain at least one entry");
+}
 const [featuredHighlight, ...supportingHighlights] = highlightsData;
 ---
 

--- a/src/pages/highlights/[slug].astro
+++ b/src/pages/highlights/[slug].astro
@@ -15,7 +15,10 @@ export function getStaticPaths() {
 const { item } = Astro.props;
 ---
 
-<BaseLayout title={`${item.title} - Highlights | TajemnikTV`}>
+<BaseLayout
+	title={`${item.title} - Highlights | TajemnikTV`}
+	description={item.hero.subtitle}
+>
 	<div class="flex min-h-screen w-full relative">
 		<Sidebar />
 
@@ -30,6 +33,7 @@ const { item } = Astro.props;
 			>
 				<span
 					class="material-symbols-outlined text-lg group-hover:-translate-x-1 transition-transform"
+					aria-hidden="true"
 					>arrow_back</span
 				>
 				Highlights
@@ -39,7 +43,8 @@ const { item } = Astro.props;
 			<header class="mb-10">
 				<GlassCard class="p-8 relative overflow-hidden">
 					<div
-						class="absolute top-0 right-0 w-64 h-64 bg-primary/10 rounded-full blur-[80px] -translate-y-1/2 translate-x-1/2 pointer-events-none"
+						class="absolute top-0 right-0 w-64 h-64 bg-white/6 rounded-full blur-[80px] -translate-y-1/2 translate-x-1/2 pointer-events-none"
+						aria-hidden="true"
 					>
 					</div>
 
@@ -49,6 +54,7 @@ const { item } = Astro.props;
 								class="w-16 h-16 rounded-2xl bg-surface-light border border-white/5 flex items-center justify-center text-primary shadow-xl"
 							>
 								<span class="material-symbols-outlined text-4xl"
+									aria-hidden="true"
 									>{item.icon}</span
 								>
 							</div>
@@ -80,7 +86,7 @@ const { item } = Astro.props;
 					item.sections.map((section) => (
 						<GlassCard class="p-6 h-full flex flex-col">
 							<h2 class="text-lg font-bold text-white mb-4 flex items-center gap-2">
-								<span class="w-1 h-6 bg-primary rounded-full" />
+								<span class="w-1 h-6 bg-primary rounded-full" aria-hidden="true" />
 								{section.title}
 							</h2>
 
@@ -95,7 +101,7 @@ const { item } = Astro.props;
 												<div class="flex items-start justify-between">
 													<div class="flex items-center gap-2">
 														{subItem.icon && (
-															<span class="material-symbols-outlined text-gray-400 text-sm group-hover:text-primary transition-colors">
+															<span class="material-symbols-outlined text-gray-400 text-sm group-hover:text-primary transition-colors" aria-hidden="true">
 																{subItem.icon}
 															</span>
 														)}
@@ -103,7 +109,7 @@ const { item } = Astro.props;
 															{subItem.label}
 														</span>
 													</div>
-													<span class="material-symbols-outlined text-gray-500 text-sm group-hover:translate-x-1 transition-transform">
+													<span class="material-symbols-outlined text-gray-500 text-sm group-hover:translate-x-1 transition-transform" aria-hidden="true">
 														arrow_forward
 													</span>
 												</div>
@@ -116,7 +122,7 @@ const { item } = Astro.props;
 										:	<div class="p-3 rounded-xl bg-white/5 border border-transparent">
 												<div class="flex items-center gap-2 mb-1">
 													{subItem.icon && (
-														<span class="material-symbols-outlined text-gray-500 text-sm">
+														<span class="material-symbols-outlined text-gray-500 text-sm" aria-hidden="true">
 															{subItem.icon}
 														</span>
 													)}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,9 +12,17 @@ import { dashboardData } from "../data/dashboard";
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 const { hero, pillars, projects, inputQueue, lab, elsewhere } = dashboardData;
+const featuredProject =
+	projects.find((project) => project.title === "TajsGraph") ?? projects[0];
+const projectIndex = projects.filter(
+	(project) => project.title !== featuredProject.title,
+);
 ---
 
-<BaseLayout title="TajemnikTV.exe | Grzegorz Kaczmarski">
+<BaseLayout
+	title="TajemnikTV.exe | Grzegorz Kaczmarski"
+	description="A dark personal dashboard for TajemnikTV: projects, lab notes, highlights, and public links from Grzegorz Kaczmarski."
+>
 	<div class="flex min-h-screen w-full relative">
 		<Sidebar />
 
@@ -38,20 +46,80 @@ const { hero, pillars, projects, inputQueue, lab, elsewhere } = dashboardData;
 					>
 						<div>
 							<p
-								class="text-xs font-bold uppercase tracking-[0.2em] text-primary mb-2"
+								class="text-xs font-bold uppercase tracking-[0.2em] text-primary/90 mb-2"
 							>
 								Project Cockpit
 							</p>
-							<h2 class="text-3xl font-bold text-white">Active chaos lanes</h2>
+							<h2 class="text-3xl font-bold text-white">Active workbench</h2>
 						</div>
 						<p class="text-sm text-gray-400 max-w-xl">
-							Things I am building, overthinking, or orbiting. Some are public,
-							some are still mostly ideas with suspiciously detailed notes.
+							One main lane gets the larger surface; the rest stay close as a
+							scannable project index.
 						</p>
 					</div>
 				</div>
 
-				{projects.map((project) => <ProjectCard {...project} />)}
+				<ProjectCard {...featuredProject} featured={true} />
+
+				<section
+					class="col-span-1 md:col-span-2 lg:col-span-2 bg-surface-dark/80 border border-white/8 rounded-2xl p-5 md:p-6"
+				>
+					<div
+						class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 mb-5"
+					>
+						<div>
+							<p
+								class="text-xs font-bold uppercase tracking-[0.18em] text-gray-500 mb-2"
+							>
+								Nearby lanes
+							</p>
+							<h3 class="text-xl font-bold text-white">Compact project index</h3>
+						</div>
+						<p class="text-xs text-gray-500 max-w-52">
+							Small surfaces for projects that need context, not another giant
+							tile.
+						</p>
+					</div>
+					<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+						{
+							projectIndex.map((project) => (
+								<a
+									href={project.href}
+									target={project.href?.startsWith("http") ? "_blank" : undefined}
+									rel={project.href?.startsWith("http") ? "noreferrer" : undefined}
+									class="group rounded-xl border border-white/7 bg-white/4 p-4 transition-all hover:border-primary/35 hover:bg-white/7 focus-visible:bg-white/8"
+								>
+									<div class="flex items-start justify-between gap-3">
+										<div>
+											<p class="text-[11px] font-bold uppercase tracking-[0.14em] text-primary/80">
+												{project.subtitle}
+											</p>
+											<h4 class="mt-1 font-bold text-white leading-tight">
+												{project.title}
+											</h4>
+										</div>
+										<span
+											class="material-symbols-outlined text-base text-white/35 group-hover:text-primary/90 transition-colors"
+											aria-hidden="true"
+										>
+											arrow_outward
+										</span>
+									</div>
+									<p class="mt-3 text-sm text-gray-400 leading-relaxed">
+										{project.description}
+									</p>
+									<div class="mt-4 flex flex-wrap gap-1.5">
+										{project.tags.slice(0, 3).map((tag) => (
+											<span class="rounded-md bg-white/5 px-2 py-1 text-[10px] font-semibold text-gray-400">
+												{tag}
+											</span>
+										))}
+									</div>
+								</a>
+							))
+						}
+					</div>
+				</section>
 
 				<div id="highlights" class="col-span-1 md:col-span-2 lg:col-span-4">
 					<div
@@ -59,7 +127,7 @@ const { hero, pillars, projects, inputQueue, lab, elsewhere } = dashboardData;
 					>
 						<div>
 							<p
-								class="text-xs font-bold uppercase tracking-[0.2em] text-primary mb-2"
+								class="text-xs font-bold uppercase tracking-[0.2em] text-primary/90 mb-2"
 							>
 								Identity Pillars
 							</p>
@@ -69,10 +137,10 @@ const { hero, pillars, projects, inputQueue, lab, elsewhere } = dashboardData;
 						</div>
 						<a
 							href="/highlights"
-							class="inline-flex items-center gap-2 text-sm font-bold text-cyan-100 hover:text-white transition-colors"
+							class="inline-flex items-center gap-2 rounded-sm text-sm font-bold text-gray-300 hover:text-white transition-colors"
 						>
 							More context
-							<span class="material-symbols-outlined text-lg"
+							<span class="material-symbols-outlined text-lg" aria-hidden="true"
 								>arrow_forward</span
 							>
 						</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,65 +60,69 @@ const projectIndex = featuredProject
 
 				{featuredProject && <ProjectCard {...featuredProject} featured={true} />}
 
-				<section
-					class="col-span-1 md:col-span-2 lg:col-span-2 bg-surface-dark/80 border border-white/8 rounded-2xl p-5 md:p-6"
-				>
-					<div
-						class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 mb-5"
-					>
-						<div>
-							<p
-								class="text-xs font-bold uppercase tracking-[0.18em] text-gray-500 mb-2"
-							>
-								Nearby lanes
-							</p>
-							<h3 class="text-xl font-bold text-white">Compact project index</h3>
-						</div>
-						<p class="text-xs text-gray-500 max-w-52">
-							Small surfaces for projects that need context, not another giant
-							tile.
-						</p>
-					</div>
-					<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-						{
-							projectIndex.map((project) => (
-								<a
-									href={project.href}
-									target={project.href?.startsWith("http") ? "_blank" : undefined}
-									rel={project.href?.startsWith("http") ? "noopener noreferrer" : undefined}
-									class="group rounded-xl border border-white/7 bg-white/4 p-4 transition-all hover:border-primary/35 hover:bg-white/7 focus-visible:bg-white/8"
-								>
-									<div class="flex items-start justify-between gap-3">
-										<div>
-											<p class="text-[11px] font-bold uppercase tracking-[0.14em] text-primary/80">
-												{project.subtitle}
-											</p>
-											<h4 class="mt-1 font-bold text-white leading-tight">
-												{project.title}
-											</h4>
-										</div>
-										<span
-											class="material-symbols-outlined text-base text-white/35 group-hover:text-primary/90 transition-colors"
-											aria-hidden="true"
-										>
-											arrow_outward
-										</span>
-									</div>
-									<p class="mt-3 text-sm text-gray-400 leading-relaxed">
-										{project.description}
+				{
+					projectIndex.length > 0 && (
+						<section class="col-span-1 md:col-span-2 lg:col-span-2 bg-surface-dark/80 border border-white/8 rounded-2xl p-5 md:p-6">
+							<div class="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 mb-5">
+								<div>
+									<p class="text-xs font-bold uppercase tracking-[0.18em] text-gray-500 mb-2">
+										Nearby lanes
 									</p>
-									<div class="mt-4 flex flex-wrap gap-1.5">
-										{project.tags.slice(0, 3).map((tag) => (
-											<span class="rounded-md bg-white/5 px-2 py-1 text-[10px] font-semibold text-gray-400">
-												{tag}
+									<h3 class="text-xl font-bold text-white">
+										Compact project index
+									</h3>
+								</div>
+								<p class="text-xs text-gray-500 max-w-52">
+									Small surfaces for projects that need context, not another giant
+									tile.
+								</p>
+							</div>
+							<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+								{projectIndex.map((project) => (
+									<a
+										href={project.href}
+										target={
+											project.href?.startsWith("http") ? "_blank" : undefined
+										}
+										rel={
+											project.href?.startsWith("http") ?
+												"noopener noreferrer"
+											:	undefined
+										}
+										class="group rounded-xl border border-white/7 bg-white/4 p-4 transition-all hover:border-primary/35 hover:bg-white/7 focus-visible:bg-white/8"
+									>
+										<div class="flex items-start justify-between gap-3">
+											<div>
+												<p class="text-[11px] font-bold uppercase tracking-[0.14em] text-primary/80">
+													{project.subtitle}
+												</p>
+												<h4 class="mt-1 font-bold text-white leading-tight">
+													{project.title}
+												</h4>
+											</div>
+											<span
+												class="material-symbols-outlined text-base text-white/35 group-hover:text-primary/90 transition-colors"
+												aria-hidden="true"
+											>
+												arrow_outward
 											</span>
-										))}
-									</div>
-								</a>
-							))
-						}
-					</div>
-				</section>
+										</div>
+										<p class="mt-3 text-sm text-gray-400 leading-relaxed">
+											{project.description}
+										</p>
+										<div class="mt-4 flex flex-wrap gap-1.5">
+											{project.tags.slice(0, 3).map((tag) => (
+												<span class="rounded-md bg-white/5 px-2 py-1 text-[10px] font-semibold text-gray-400">
+													{tag}
+												</span>
+											))}
+										</div>
+									</a>
+								))}
+							</div>
+						</section>
+					)
+				}
 
 				<div id="highlights" class="col-span-1 md:col-span-2 lg:col-span-4">
 					<div

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,11 +12,10 @@ import { dashboardData } from "../data/dashboard";
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 const { hero, pillars, projects, inputQueue, lab, elsewhere } = dashboardData;
-const featuredProject =
-	projects.find((project) => project.title === "TajsGraph") ?? projects[0];
-const projectIndex = projects.filter(
-	(project) => project.title !== featuredProject.title,
-);
+const featuredProject = projects.find((project) => project.featured) ?? projects[0];
+const projectIndex = featuredProject
+	? projects.filter((project) => project !== featuredProject)
+	: [];
 ---
 
 <BaseLayout
@@ -59,7 +58,7 @@ const projectIndex = projects.filter(
 					</div>
 				</div>
 
-				<ProjectCard {...featuredProject} featured={true} />
+				{featuredProject && <ProjectCard {...featuredProject} featured={true} />}
 
 				<section
 					class="col-span-1 md:col-span-2 lg:col-span-2 bg-surface-dark/80 border border-white/8 rounded-2xl p-5 md:p-6"
@@ -86,7 +85,7 @@ const projectIndex = projects.filter(
 								<a
 									href={project.href}
 									target={project.href?.startsWith("http") ? "_blank" : undefined}
-									rel={project.href?.startsWith("http") ? "noreferrer" : undefined}
+									rel={project.href?.startsWith("http") ? "noopener noreferrer" : undefined}
 									class="group rounded-xl border border-white/7 bg-white/4 p-4 transition-all hover:border-primary/35 hover:bg-white/7 focus-visible:bg-white/8"
 								>
 									<div class="flex items-start justify-between gap-3">

--- a/src/pages/lab/[slug].astro
+++ b/src/pages/lab/[slug].astro
@@ -29,7 +29,10 @@ const wordCount = post.body?.trim().match(/\S+/g)?.length ?? 0;
 const readTime = Math.ceil(wordCount / 200);
 ---
 
-<BaseLayout title={`${post.data.title} | Lab Notes | TajemnikTV`}>
+<BaseLayout
+	title={`${post.data.title} | Lab Notes | TajemnikTV`}
+	description={post.data.description}
+>
 	<div class="flex min-h-screen w-full relative">
 		<Sidebar />
 
@@ -44,6 +47,7 @@ const readTime = Math.ceil(wordCount / 200);
 			>
 				<span
 					class="material-symbols-outlined text-lg group-hover:-translate-x-1 transition-transform"
+					aria-hidden="true"
 					>arrow_back</span
 				>
 				Back to Lab Notes
@@ -64,12 +68,13 @@ const readTime = Math.ceil(wordCount / 200);
 					<div class="flex items-center gap-4 text-sm text-gray-400">
 						<span class="flex items-center gap-1">
 							<span class="material-symbols-outlined text-base"
+								aria-hidden="true"
 								>calendar_today</span
 							>
 							{formattedDate}
 						</span>
 						<span class="flex items-center gap-1">
-							<span class="material-symbols-outlined text-base">schedule</span>
+							<span class="material-symbols-outlined text-base" aria-hidden="true">schedule</span>
 							{readTime} min scan
 						</span>
 					</div>

--- a/src/pages/lab/index.astro
+++ b/src/pages/lab/index.astro
@@ -15,7 +15,10 @@ const tags = [...new Set(notes.flatMap((post) => post.data.tags))];
 const { lab } = dashboardData;
 ---
 
-<BaseLayout title="Lab Notes | TajemnikTV">
+<BaseLayout
+	title="Lab Notes | TajemnikTV"
+	description="Selective lab notes from TajemnikTV: project logs, research trails, and practical experiments."
+>
 	<div class="flex min-h-screen w-full relative">
 		<Sidebar />
 
@@ -30,11 +33,11 @@ const { lab } = dashboardData;
 				>
 					TajemnikTV research-ish terminal
 				</p>
-				<h1 class="text-4xl md:text-5xl font-bold mb-4 gradient-text">
+				<h1 class="text-4xl md:text-5xl font-bold mb-4 text-white">
 					Lab Notes
 				</h1>
 				<p class="text-lg text-gray-300 max-w-3xl leading-relaxed">
-					Experiments, project notes, rabbit holes, and thoughts that are useful
+					Experiments, project logs, research trails, and thoughts that are useful
 					enough to escape the private notes folder. This is not pretending to
 					be a formal blog.
 				</p>
@@ -52,7 +55,7 @@ const { lab } = dashboardData;
 									placeholder="Search lab notes..."
 									class="w-full bg-surface-dark border border-white/10 rounded-full px-4 py-2 text-sm text-white focus:outline-none focus:border-primary/50 transition-colors pl-10"
 								/>
-								<span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 text-sm">
+								<span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 text-sm" aria-hidden="true">
 									search
 								</span>
 							</div>
@@ -92,10 +95,10 @@ const { lab } = dashboardData;
 				:	<GlassCard class="p-8 md:p-10">
 						<div class="flex flex-col md:flex-row gap-6 md:items-center">
 							<div class="h-16 w-16 rounded-2xl bg-primary/20 text-primary flex items-center justify-center shrink-0">
-								<span class="material-symbols-outlined text-4xl">science</span>
+								<span class="material-symbols-outlined text-4xl" aria-hidden="true">science</span>
 							</div>
 							<div>
-								<p class="text-xs font-bold uppercase tracking-[0.18em] text-cyan-100/70 mb-2">
+								<p class="text-xs font-bold uppercase tracking-[0.18em] text-gray-400 mb-2">
 									{lab.status}
 								</p>
 								<h2 class="text-2xl font-bold text-white mb-3">
@@ -135,7 +138,7 @@ const { lab } = dashboardData;
 			const matchesSearch = postTitle.includes(currentSearch.toLowerCase());
 
 			if (matchesTag && matchesSearch) {
-				(post as HTMLElement).style.display = "block";
+				(post as HTMLElement).style.display = "";
 				visibleCount++;
 			} else {
 				(post as HTMLElement).style.display = "none";

--- a/src/pages/writing/[slug].astro
+++ b/src/pages/writing/[slug].astro
@@ -31,7 +31,7 @@ const { slug } = Astro.params;
 				class="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-3 text-sm font-bold text-white"
 			>
 				Open Lab Note
-				<span class="material-symbols-outlined text-lg">arrow_forward</span>
+				<span class="material-symbols-outlined text-lg" aria-hidden="true">arrow_forward</span>
 			</a>
 		</div>
 	</main>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -20,7 +20,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 				class="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-3 text-sm font-bold text-white"
 			>
 				Open Lab Notes
-				<span class="material-symbols-outlined text-lg">arrow_forward</span>
+				<span class="material-symbols-outlined text-lg" aria-hidden="true">arrow_forward</span>
 			</a>
 		</div>
 	</main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,7 +5,28 @@
 
 @layer base {
 	html {
-		background-color: #130b1a;
+		background-color: #120d17;
+	}
+
+	body::before {
+		content: "";
+		position: fixed;
+		inset: 0;
+		pointer-events: none;
+		z-index: 60;
+		opacity: 0.18;
+		background-image:
+			linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+			linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px);
+		background-size: 3px 3px, 37px 37px;
+		mix-blend-mode: soft-light;
+	}
+
+	a:focus-visible,
+	button:focus-visible,
+	input:focus-visible {
+		outline: 2px solid rgba(173, 146, 201, 0.95);
+		outline-offset: 3px;
 	}
 }
 
@@ -14,25 +35,26 @@
 	width: 8px;
 }
 ::-webkit-scrollbar-track {
-	background: #130b1a;
+	background: #120d17;
 }
 ::-webkit-scrollbar-thumb {
-	background: #362348;
+	background: #3a3042;
 	border-radius: 10px;
 }
 ::-webkit-scrollbar-thumb:hover {
-	background: #7f13ec;
+	background: #8c6aaa;
 }
 
 /* Utilities */
 .glass-card {
-	background: rgba(31, 20, 41, 0.7);
-	backdrop-filter: blur(12px);
-	border: 1px solid rgba(127, 19, 236, 0.1);
+	background: rgba(28, 22, 34, 0.74);
+	backdrop-filter: blur(14px);
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.045);
 }
 
 .gradient-text {
-	background: linear-gradient(135deg, #fff 0%, #ad92c9 100%);
+	background: linear-gradient(135deg, #fff 0%, #c4b6d3 100%);
 	-webkit-background-clip: text;
 	-webkit-text-fill-color: transparent;
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -9,12 +9,12 @@ export default {
 	theme: {
 		extend: {
 			colors: {
-				"primary": "#7f13ec",
+				"primary": "#8f5cc7",
 				"background-light": "#f7f6f8",
-				"background-dark": "#130b1a",
-				"surface-dark": "#1f1429",
-				"surface-light": "#2a1d35",
-				"accent-purple": "#9d4edd",
+				"background-dark": "#120d17",
+				"surface-dark": "#1d1724",
+				"surface-light": "#2a2231",
+				"accent-purple": "#b28ad8",
 			},
 			fontFamily: {
 				display: ["Spline Sans", "sans-serif"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Polished the dashboard with a featured project layout, a reworked Highlights page, and stronger SEO/accessibility. Improves visual contrast, focus states, and copy across pages.

- New Features
  - `BaseLayout` now takes `description`/`image` and emits canonical, Open Graph, and Twitter tags; adds a default social card at `public/images/og-card.svg`.
  - Highlights: lead thread card + supporting list, clearer copy, and page-level meta description.
  - Projects: `ProjectCard` adds `featured`; home shows one featured lane plus a compact project index.
  - Global focus outlines and a subtle background grid for polish.

- Refactors
  - Color/shadow tuning in `tailwind.config.mjs` and `global.css` (neutral shadows, updated primary, glass borders, scrollbar).
  - Accessibility: decorative icons `aria-hidden`, external links use `rel="noopener noreferrer"`, and nav tooltips now show on keyboard focus.
  - Copy and visual tweaks across cards and pages (Hero/Reading/Lab/Connect/404), more consistent headers.
  - Pages now pass descriptions to `BaseLayout` (home, highlights list/detail, lab list/detail, connect) for richer metadata.

<sup>Written for commit b33ae35327ff8f8e80ff6579fe91cb1e1aa1f0a1. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/tajemniktv.github.io/pull/25?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

